### PR TITLE
Support measure response after boot

### DIFF
--- a/src/airgradient/models.py
+++ b/src/airgradient/models.py
@@ -14,20 +14,30 @@ class Measures(DataClassORJSONMixin):
 
     signal_strength: int = field(metadata=field_options(alias="wifi"))
     serial_number: str = field(metadata=field_options(alias="serialno"))
-    rco2: int
-    pm01: int
-    pm02: int
-    pm10: int
-    pm003_count: int = field(metadata=field_options(alias="pm003Count"))
-    total_volatile_organic_component_index: int = field(
-        metadata=field_options(alias="tvocIndex")
-    )
-    raw_total_volatile_organic_component: int = field(
-        metadata=field_options(alias="tvoc_raw")
-    )
-    nitrogen_index: int = field(metadata=field_options(alias="noxIndex"))
-    raw_nitrogen: int = field(metadata=field_options(alias="nox_raw"))
-    ambient_temperature: float = field(metadata=field_options(alias="atmp"))
-    relative_humidity: float = field(metadata=field_options(alias="rhum"))
     boot_time: int = field(metadata=field_options(alias="boot"))
     firmware_version: str = field(metadata=field_options(alias="firmwareVersion"))
+    rco2: int | None = None
+    pm01: int | None = None
+    pm02: int | None = None
+    pm10: int | None = None
+    total_volatile_organic_component_index: int | None = field(
+        default=None, metadata=field_options(alias="tvocIndex")
+    )
+    raw_total_volatile_organic_component: int | None = field(
+        default=None, metadata=field_options(alias="tvoc_raw")
+    )
+    pm003_count: int | None = field(
+        default=None, metadata=field_options(alias="pm003Count")
+    )
+    nitrogen_index: int | None = field(
+        default=None, metadata=field_options(alias="noxIndex")
+    )
+    raw_nitrogen: int | None = field(
+        default=None, metadata=field_options(alias="nox_raw")
+    )
+    ambient_temperature: float | None = field(
+        default=None, metadata=field_options(alias="atmp")
+    )
+    relative_humidity: float | None = field(
+        default=None, metadata=field_options(alias="rhum")
+    )

--- a/tests/__snapshots__/test_airgradient.ambr
+++ b/tests/__snapshots__/test_airgradient.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_status
+# name: test_current_fixtures[current_measures.json]
   dict({
     'ambient_temperature': 27.96,
     'boot_time': 28,
@@ -16,5 +16,24 @@
     'serial_number': '84fce612f5b8',
     'signal_strength': -52,
     'total_volatile_organic_component_index': 99,
+  })
+# ---
+# name: test_current_fixtures[measures_after_boot.json]
+  dict({
+    'ambient_temperature': None,
+    'boot_time': 0,
+    'firmware_version': '3.0.8',
+    'nitrogen_index': None,
+    'pm003_count': None,
+    'pm01': None,
+    'pm02': None,
+    'pm10': None,
+    'raw_nitrogen': None,
+    'raw_total_volatile_organic_component': None,
+    'rco2': None,
+    'relative_humidity': None,
+    'serial_number': '84fce612f5b8',
+    'signal_strength': -59,
+    'total_volatile_organic_component_index': None,
   })
 # ---

--- a/tests/fixtures/measures_after_boot.json
+++ b/tests/fixtures/measures_after_boot.json
@@ -1,0 +1,7 @@
+{
+    "wifi": -59,
+    "serialno": "84fce612f5b8",
+    "boot": 0,
+    "ledMode": "co2",
+    "firmwareVersion": "3.0.8"
+}

--- a/tests/test_airgradient.py
+++ b/tests/test_airgradient.py
@@ -87,15 +87,20 @@ async def test_timeout(
             assert await airgradient.get_current_measures()
 
 
-async def test_status(
+@pytest.mark.parametrize(
+    "fixture",
+    ["current_measures.json", "measures_after_boot.json"],
+)
+async def test_current_fixtures(
     responses: aioresponses,
     client: AirGradientClient,
     snapshot: SnapshotAssertion,
+    fixture: str,
 ) -> None:
     """Test status call."""
     responses.get(
         f"{MOCK_URL}/measures/current",
         status=200,
-        body=load_fixture("current_measures.json"),
+        body=load_fixture(fixture),
     )
     assert await client.get_current_measures() == snapshot


### PR DESCRIPTION
Apparently right after booting all values are not present in the data. This way we set them to None when we don't retrieve them.