### PR TITLE
Wrap mashumaro exceptions in an airgradient specific exception

### DIFF
--- a/src/airgradient/__init__.py
+++ b/src/airgradient/__init__.py
@@ -1,7 +1,7 @@
 """Asynchronous Python client for AirGradient."""
 
 from airgradient.airgradient import AirGradientClient
-from airgradient.exceptions import AirGradientConnectionError, AirGradientError
+from airgradient.exceptions import AirGradientConnectionError, AirGradientError, AirGradientParseError
 from airgradient.models import (
     Config,
     ConfigurationControl,
@@ -16,6 +16,7 @@ __all__ = [
     "AirGradientClient",
     "AirGradientError",
     "AirGradientConnectionError",
+    "AirGradientParseError",
     "Measures",
     "Config",
     "PmStandard",

--- a/src/airgradient/__init__.py
+++ b/src/airgradient/__init__.py
@@ -1,7 +1,11 @@
 """Asynchronous Python client for AirGradient."""
 
 from airgradient.airgradient import AirGradientClient
-from airgradient.exceptions import AirGradientConnectionError, AirGradientError, AirGradientParseError
+from airgradient.exceptions import (
+    AirGradientConnectionError,
+    AirGradientError,
+    AirGradientParseError,
+)
 from airgradient.models import (
     Config,
     ConfigurationControl,

--- a/src/airgradient/airgradient.py
+++ b/src/airgradient/airgradient.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING, Any
 from aiohttp import ClientError, ClientResponseError, ClientSession
 from aiohttp.hdrs import METH_GET, METH_PUT
 from yarl import URL
+from mashumaro import MissingField
 
-from .exceptions import AirGradientConnectionError
+from .exceptions import AirGradientConnectionError, AirGradientParseError
 from .models import (
     Config,
     ConfigurationControl,
@@ -90,12 +91,18 @@ class AirGradientClient:
     async def get_current_measures(self) -> Measures:
         """Get current measures from AirGradient."""
         response = await self._request("measures/current")
-        return Measures.from_json(response)
+        try:
+            return Measures.from_json(response)
+        except MissingField as err:
+            raise AirGradientParseError from err
 
     async def get_config(self) -> Config:
         """Get config from AirGradient device."""
         response = await self._request("config")
-        return Config.from_json(response)
+        try:
+            return Config.from_json(response)
+        except MissingField as err:
+            raise AirGradientParseError from err
 
     async def _set_config(self, field: str, value: Any) -> None:
         """Set config on AirGradient device."""

--- a/src/airgradient/airgradient.py
+++ b/src/airgradient/airgradient.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientError, ClientResponseError, ClientSession
 from aiohttp.hdrs import METH_GET, METH_PUT
-from yarl import URL
 from mashumaro import MissingField
+from yarl import URL
 
 from .exceptions import AirGradientConnectionError, AirGradientParseError
 from .models import (

--- a/src/airgradient/exceptions.py
+++ b/src/airgradient/exceptions.py
@@ -7,3 +7,7 @@ class AirGradientError(Exception):
 
 class AirGradientConnectionError(AirGradientError):
     """AirGradient connection exception."""
+
+
+class AirGradientParseError(AirGradientError):
+    """AirGradient parse exception."""

--- a/tests/test_airgradient.py
+++ b/tests/test_airgradient.py
@@ -15,11 +15,11 @@ from airgradient import (
     AirGradientClient,
     AirGradientConnectionError,
     AirGradientError,
+    AirGradientParseError,
     ConfigurationControl,
     LedBarMode,
     PmStandard,
     TemperatureUnit,
-    AirGradientParseError,
 )
 from tests import load_fixture
 from tests.const import HEADERS, MOCK_HOST, MOCK_URL

--- a/tests/test_airgradient.py
+++ b/tests/test_airgradient.py
@@ -19,6 +19,7 @@ from airgradient import (
     LedBarMode,
     PmStandard,
     TemperatureUnit,
+    AirGradientParseError,
 )
 from tests import load_fixture
 from tests.const import HEADERS, MOCK_HOST, MOCK_URL
@@ -74,7 +75,32 @@ async def test_unexpected_server_response(
         body="Yes",
     )
     with pytest.raises(AirGradientError):
-        assert await client.get_current_measures()
+        await client.get_current_measures()
+
+
+async def test_unexpected_server_json_response(
+    client: AirGradientClient,
+    responses: aioresponses,
+) -> None:
+    """Test handling unexpected response missing required fields."""
+
+    async def response_handler(_: str, **_kwargs: Any) -> CallbackResult:
+        """Response handler for this test."""
+        return CallbackResult(payload={})
+
+    responses.get(
+        f"{MOCK_URL}/measures/current",
+        callback=response_handler,
+    )
+    with pytest.raises(AirGradientParseError):
+        await client.get_current_measures()
+
+    responses.get(
+        f"{MOCK_URL}/config",
+        callback=response_handler,
+    )
+    with pytest.raises(AirGradientParseError):
+        await client.get_config()
 
 
 async def test_timeout(
@@ -94,7 +120,7 @@ async def test_timeout(
     )
     async with AirGradientClient(request_timeout=1, host=MOCK_HOST) as airgradient:
         with pytest.raises(AirGradientConnectionError):
-            assert await airgradient.get_current_measures()
+            await airgradient.get_current_measures()
 
 
 async def test_client_error(
@@ -107,12 +133,12 @@ async def test_client_error(
         """Response handler for this test."""
         raise ClientError
 
-    responses.post(
+    responses.get(
         f"{MOCK_URL}/measures/current",
         callback=response_handler,
     )
     with pytest.raises(AirGradientConnectionError):
-        assert await client.get_current_measures()
+        await client.get_current_measures()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Proposed Changes

Catch mashumaro exceptions and rethrow them to avoid leaking the parsling library internal details to the caller.

## Related Issues

Followup from https://github.com/home-assistant/core/pull/121859

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
